### PR TITLE
Present compat

### DIFF
--- a/flaskr/__init__.py
+++ b/flaskr/__init__.py
@@ -126,9 +126,6 @@ def create_app(test_config=None):
 				session['compatPercent'] = algorithm.compare_profiles(p1, p2)
 				print(session['compatPercent'])
 				print("Compatibility Percentage: " + str(session['compatPercent']['COMPAT']), file=sys.stderr)
-				
-				# TODO: present compatibility result
-				# Currently redirects to home page
 
 				return redirect(url_for('compat'))
 			else:

--- a/flaskr/__init__.py
+++ b/flaskr/__init__.py
@@ -167,7 +167,8 @@ def create_app(test_config=None):
 
 	@app.route('/compat')
 	def compat():
-		return redirect(url_for('index'))
+		results = session['compatPercent']
+		return render_template('compat.html', results=results)
 
 	# Remove stock symbol from table
 	@app.route('/remove/<key>')

--- a/flaskr/static/css/style.css
+++ b/flaskr/static/css/style.css
@@ -34,6 +34,11 @@ a {
     list-style-type: none;
     display: flex;
     align-items: center;
+    margin: 0;
+}
+.menu a{
+  color: white;
+  text-decoration: none;
 }
 .logo {
     font-size: 20px;
@@ -187,7 +192,7 @@ input[type=submit]:hover {
   color: white;
   cursor: pointer;
   padding: 18px;
-  width: 50%;
+  width: 60%;
   border: none;
   text-align: left;
   outline: none;
@@ -204,7 +209,7 @@ input[type=submit]:hover {
   opacity: 0;
 }
 .content {
-  width: 50%;
+  width: 60%;
   padding: 0 16px;
   background-color: #f1f1f1;
   max-height: 0;
@@ -223,6 +228,29 @@ input[type=submit]:hover {
 }
 .text-center{
   text-align: center;
+}
+
+/* Compatibility */
+.compat {
+  font-size: 1.5em;
+}
+.iparent {
+  display: flex;
+  flex-wrap: wrap;
+  width: 70%;
+}
+.ichild {
+  flex: 1 0 10%;
+  margin: 5px;
+  font-size: 3em;
+  text-align: center;
+  color: #888;
+}
+.ichild.num {
+  margin: auto;
+}
+.ichild.des {
+  font-size: 16px;
 }
 
 @media (min-width: 481px) and (max-width: 768px)

--- a/flaskr/static/css/style.css
+++ b/flaskr/static/css/style.css
@@ -40,6 +40,10 @@ a {
   color: white;
   text-decoration: none;
 }
+.logo a:hover{
+  color: white;
+  text-decoration: none;
+}
 .logo {
     font-size: 20px;
     padding: 7.5px 10px 7.5px 0;
@@ -201,6 +205,10 @@ input[type=submit]:hover {
 .active, .collapsible:hover {
   background-color: #555;
   color: white;
+  outline: none;
+}
+.active, .collapsible:focus{
+  outline: none;
 }
 .collapsible span {
   float: right;
@@ -244,7 +252,7 @@ input[type=submit]:hover {
   margin: 5px;
   font-size: 3em;
   text-align: center;
-  color: #888;
+  color: #999;
 }
 .ichild.num {
   margin: auto;
@@ -269,6 +277,9 @@ input[type=submit]:hover {
   .collapsible, .content{
     width:90%;
   }
+  .iparent {
+    width:90%;
+  }
 }
 @media (max-width: 480px)
 {
@@ -284,6 +295,9 @@ input[type=submit]:hover {
   .collapsible, .content{
     width:95%;
     font-size: 20px;
+  }
+  .iparent {
+    width: 100%;
   }
   #about {display: none;}
 }

--- a/flaskr/templates/base.html
+++ b/flaskr/templates/base.html
@@ -10,7 +10,7 @@
     <nav>
 	  <ul class="menu">
 	    <li class="logo"><a href="{{ url_for('index')}}">StockMeetsBagel</a></li>
-	    <li class="item" id="about"><a href="#">About</a></li>
+	    <li class="item" id="about"><a href="{{ url_for('index')}}">Home</a></li>
 	    </li>
 	    <li class="item button"><a href="{{ url_for('compare')}}">Compare</a></li>
 	    <li class="toggle"><a href="#"><i class="fas fa-bars"></i></a></li>

--- a/flaskr/templates/base.html
+++ b/flaskr/templates/base.html
@@ -10,8 +10,8 @@
     <nav>
 	  <ul class="menu">
 	    <li class="logo"><a href="{{ url_for('index')}}">StockMeetsBagel</a></li>
-	    <li class="item" id="about"><a href="{{ url_for('index')}}">Home</a></li>
-	    </li>
+	    <li class="item"><a href="{{ url_for('index')}}">Home</a></li>
+	    <li class="item" id="about"><a href="#">About</a></li>
 	    <li class="item button"><a href="{{ url_for('compare')}}">Compare</a></li>
 	    <li class="toggle"><a href="#"><i class="fas fa-bars"></i></a></li>
 	  </ul>

--- a/flaskr/templates/compat.html
+++ b/flaskr/templates/compat.html
@@ -60,6 +60,16 @@
 	    </div>
 	{% endif %}
 <script>
+	function adjustCompatForPhone(x, iscore) {
+	  if (x.matches) { // If media query matches
+	  	for (i = 1; i <= 5; i++) {
+	  		if (i == iscore) continue;
+	  		document.getElementById("i"+i).style.display = "none";
+	  		document.getElementById("d"+i).style.display = "none";
+	  	}
+	  } 
+	}
+
 	// QUESTION: what's the range of INVDIF? 0-5?
 	var iscore = {{ results['INVDIF']|safe }};
 	if (iscore < 1) {iscore = 1;}
@@ -67,6 +77,11 @@
 	document.getElementById("i"+iscore).style.color = "black";
 	document.getElementById("i"+iscore).style.fontSize = "3.5em";
 	document.getElementById("d"+iscore).style.color = "black";
+
+	// phone screen
+	var x = window.matchMedia("(max-width: 400px)");
+	adjustCompatForPhone(x, iscore);
+	x.addListener(adjustCompatForPhone);
 
 </script>
 {% endblock %}

--- a/flaskr/templates/compat.html
+++ b/flaskr/templates/compat.html
@@ -4,7 +4,7 @@
 
 <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
 
-	<h1>{% block title %}Your Compatibility is {{ results['COMPAT'] }}% !{% endblock %}</h1>
+	<h1>{% block title %}Your Compatibility is {{ results['COMPAT'] }}%{% endblock %}</h1>
 	<p></p>
     <div class="progress" style="width:70%">
         <div class="progress-bar progress-bar-striped active" role="progressbar"
@@ -14,35 +14,59 @@
     </div>
 	<p></p>
 
+	<h2 class="pad-m text-center compat">Here's how well you matched for each of these traits.</h2>
 	<button type="button" class="collapsible pad-s">(E) Exploratory Excitability and Extravagance: {{ results['EXPEXT'] }}%<span>+</span></button>
 	<div class="content">
-	  <p><b>Exploratory excitability</b> refers to one's willingness and desire to seek new things and avoid boredom. <b>Extravagance</b> refers to one's preference for spending money over saving money. Thus, a higher score suggests you like new stimuli, utilizing the money at your disposal, and portfolios with more <ins>growth & large capitalization stocks</ins>.
+	  <p>A higher number in the <b>E</b> category indicates you and your partner have similar levels of adventurousness when it comes to finding enjoyment in performing activities in everyday life. <br><br>Partners with similar E scores find it easier to spend quality time together and tend to take pleasure in similar types of hobbies. They also share similar attitudes towards money management and financial decision-making, a critical cornerstone to every successful relationship. Thus, these types of couples will find it easier to maintain stability and sustain a long-term relationship. 
 	  </p>
 	</div>
 	<button type="button" class="collapsible">(I) Impulsiveness and Disorderliness: {{ results['IMPDIS'] }}%<span>+</span></button>
 	<div class="content">
-	  <p><b>Impulsiveness</b> refers to one's willingness to make decisions based on hunches without necessarily having complete information. <b>Disorderliness</b> refers to one's willingness to do things their own way without much regard for routines or rules. Thus, a higher score suggests you take risks, do not follow conventions, and have a portfolio with more <ins>growth & small capitalization stocks</ins>.
+	  <p>A higher number in the <b>I</b> category suggests you and your partner share similar views on risk-taking and decision-making. <br><br>Couples who are similarly impulsive with not much regard to rules or regulations find the most fun and freedom when in each other's company. As a result the physical compatibility of such individuals also tends to be quite high. Partners with one-night stands typically fall into this category. <br><br>Couples who are equally averse to risk-taking and instead prefer making "safe" decisions tend to have more relationship stability. However, the long-term effects of such mundanity and uptightness in everyday life can often manifest itself in heightened sexual tension and restlessness between partners.
 	  </p>
 	</div>
 	<button type="button" class="collapsible">(A) Attachment and Dependence: {{ results['ATTDEP'] }}%<span>+</span></button>
 	<div class="content">
-	  <p><b>Attachment</b> refers to one's tendency to be generally warm and open with others. <b>Dependence</b> refers to one's willingness and desire to fit into a social group. Thus, a higher score suggests you are more amicable, enjoy interacting with people, and have a portfolio with more <ins>small capitalization stocks</ins>.
+	  <p>A higher number in the <b>A</b> category means you and your partner have similar levels of openness to others and exhibit similar behaviors and attitudes towards social situations. <br><br>Couples who both have high A scores enjoy social interaction and mingling with different groups of people and are often the life of the party. However, such behavior can sometimes brood jealousy between couples if they feel their partner is giving too much attention to others. Cheating also arises most frequently between these types of couples. <br><br>Couples who both have low A scores do not enjoy social gatherings and much prefer to keep to themselves and enjoy each other's company. However, the more they rely on each other as their only sole of human interaction, the more distraught these couples will feel in times of long-distance separation. As such, breakups will be emotionally destructive for both parties, so such couples should be wary of this fact and ensure they have healthy coping mechanisms. 
 	  </p>
 	</div>
 	<button type="button" class="collapsible">(S) Sentimentality and Empathy: {{ results['SENTIM'] }}%<span>+</span></button>
 	<div class="content">
-	  <p><b>Sentimentality</b> refers to one's tendency to be affected by emotional stimuli, whether it be other people or works of art. <b>Empathy</b> refers to one's ability to better understand and share the feelings of others. Thus, a higher score suggests you are more led by your emotions, understand the emotions of others, and have a portfolio with more <ins>value and small capitalization stocks</ins>.
-	  </p>
-	</div>
-	<button type="button" class="collapsible">Investment (0-5): {{ results['INVDIF'] }}<span>+</span></button>
-	<div class="content">
-	  <p><b>HELLO</b> content</ins>.
+	  <p>A higher number in the <b>S</b> category indicates you and your parter exhibit similar levels of understanding towards people and have similar emotional intelligence. <br><br>Couples who both have high levels of empathy find it easier to be emotionally vulnerable with and reliant on each other for comfort in times of distress. <br><br>Couple who both have low empathy may find it harder to relate to each other's troubles and find themselves unable to emotionally support each other. However, their ability to emotionally detach themselves at the right times using logic and reason is also an important strength of such couples. 
 	  </p>
 	</div>
 
-	<button type="button" class="collapsible">Mutual Hobbies: {{ results['HOBCHK'] }}<span>+</span></button>
-	<div class="content">
-	  <p><b>HELLO</b> content</ins>.
-	  </p>
+	<h2 class="pad-m text-center compat">Here's your <b>investment</b> score out of 5.</h2>
+	<div class="iparent">
+		<div class="ichild num" id="i1">1</div>
+		<div class="ichild num" id="i2">2</div>
+		<div class="ichild num" id="i3">3</div>
+		<div class="ichild num" id="i4">4</div>
+		<div class="ichild num" id="i5">5</div>
 	</div>
+	<div class="iparent">
+		<div class="ichild des" id="d1">Your investment choices are virtually the same.</div>
+		<div class="ichild des" id="d2">Your investment choices are mostly aligned. </div>
+		<div class="ichild des" id="d3">You and your partner have similar investing habits.</div>
+		<div class="ichild des" id="d4">Your investment choices have little similarity.</div>
+		<div class="ichild des" id="d5">Your investment choices differ largely.</div>
+	</div>
+
+
+	{% if results['HOBCHK']|length %}
+	    <h2 class="pad-m text-center compat">Here are some mutual hobbies we found.</h2>
+	    <div class="info flex-center">
+	    	<p>results['HOBCHK']</p>
+	    </div>
+	{% endif %}
+<script>
+	// QUESTION: what's the range of INVDIF? 0-5?
+	var iscore = {{ results['INVDIF']|safe }};
+	if (iscore < 1) {iscore = 1;}
+	if (iscore > 5) {iscore = 5;}
+	document.getElementById("i"+iscore).style.color = "black";
+	document.getElementById("i"+iscore).style.fontSize = "3.5em";
+	document.getElementById("d"+iscore).style.color = "black";
+
+</script>
 {% endblock %}

--- a/flaskr/templates/compat.html
+++ b/flaskr/templates/compat.html
@@ -1,0 +1,48 @@
+{% extends 'base.html' %}
+
+{% block content %}
+
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+
+	<h1>{% block title %}Your Compatibility is {{ results['COMPAT'] }}% !{% endblock %}</h1>
+	<p></p>
+    <div class="progress" style="width:70%">
+        <div class="progress-bar progress-bar-striped active" role="progressbar"
+        aria-valuenow="{{ results['COMPAT'] }}" aria-valuemin="0" aria-valuemax="100" style="width: {{ results['COMPAT'] }}%">
+          {{ results['COMPAT'] }}%
+        </div>
+    </div>
+	<p></p>
+
+	<button type="button" class="collapsible pad-s">(E) Exploratory Excitability and Extravagance: {{ results['EXPEXT'] }}%<span>+</span></button>
+	<div class="content">
+	  <p><b>Exploratory excitability</b> refers to one's willingness and desire to seek new things and avoid boredom. <b>Extravagance</b> refers to one's preference for spending money over saving money. Thus, a higher score suggests you like new stimuli, utilizing the money at your disposal, and portfolios with more <ins>growth & large capitalization stocks</ins>.
+	  </p>
+	</div>
+	<button type="button" class="collapsible">(I) Impulsiveness and Disorderliness: {{ results['IMPDIS'] }}%<span>+</span></button>
+	<div class="content">
+	  <p><b>Impulsiveness</b> refers to one's willingness to make decisions based on hunches without necessarily having complete information. <b>Disorderliness</b> refers to one's willingness to do things their own way without much regard for routines or rules. Thus, a higher score suggests you take risks, do not follow conventions, and have a portfolio with more <ins>growth & small capitalization stocks</ins>.
+	  </p>
+	</div>
+	<button type="button" class="collapsible">(A) Attachment and Dependence: {{ results['ATTDEP'] }}%<span>+</span></button>
+	<div class="content">
+	  <p><b>Attachment</b> refers to one's tendency to be generally warm and open with others. <b>Dependence</b> refers to one's willingness and desire to fit into a social group. Thus, a higher score suggests you are more amicable, enjoy interacting with people, and have a portfolio with more <ins>small capitalization stocks</ins>.
+	  </p>
+	</div>
+	<button type="button" class="collapsible">(S) Sentimentality and Empathy: {{ results['SENTIM'] }}%<span>+</span></button>
+	<div class="content">
+	  <p><b>Sentimentality</b> refers to one's tendency to be affected by emotional stimuli, whether it be other people or works of art. <b>Empathy</b> refers to one's ability to better understand and share the feelings of others. Thus, a higher score suggests you are more led by your emotions, understand the emotions of others, and have a portfolio with more <ins>value and small capitalization stocks</ins>.
+	  </p>
+	</div>
+	<button type="button" class="collapsible">Investment (0-5): {{ results['INVDIF'] }}<span>+</span></button>
+	<div class="content">
+	  <p><b>HELLO</b> content</ins>.
+	  </p>
+	</div>
+
+	<button type="button" class="collapsible">Mutual Hobbies: {{ results['HOBCHK'] }}<span>+</span></button>
+	<div class="content">
+	  <p><b>HELLO</b> content</ins>.
+	  </p>
+	</div>
+{% endblock %}

--- a/flaskr/templates/index.html
+++ b/flaskr/templates/index.html
@@ -2,7 +2,7 @@
 
 {% block content %}
     <h1>{% block title %} Welcome to StockMeetsBagel {% endblock %}</h1>
-	<h2>Start by inputting your stonk information below</h2>
+	<h2>Start by inputting your stock information below</h2>
 	{% for message in get_flashed_messages() %}
 		<div class="flash">{{ message }}</div>
 	{% endfor %}
@@ -14,7 +14,7 @@
 	    <input type="submit" value="Add Stock">
   	</form>
   	{% if stock_dict is none %}
-	<p> Have a user ID already? Go to Compare</p>
+	<p> Have an ID already? Go to Compare</p>
 	{% else %}
   	<div class="selected-stocks table-container" role="table">
   		<div class="flex-table row" role="rowgroup">

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -34,4 +34,4 @@ def test_post_compare(client):
             person1=TEST_ID1,
             person2=TEST_ID2
     ), follow_redirects=True)
-    assert b"Investment (0-5):" in post_response.data
+    assert b"Your Compatibility is" in post_response.data

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -34,4 +34,4 @@ def test_post_compare(client):
             person1=TEST_ID1,
             person2=TEST_ID2
     ), follow_redirects=True)
-    assert b"Welcome to StockMeetsBagel" in post_response.data
+    assert b"Investment (0-5):" in post_response.data


### PR DESCRIPTION
Closes #37 

- "Compare My Results" now redirects to compat page
- Compat page displays 4 personality categories and % compatibility scores, with descriptions
- "Investment" category added as a number line

TODO:

- "Investment" descriptions? I'm still not quite sure what it means. Maybe we can change the name too so it's more intuitive? (Also change scale from 5 is most similar, while 1 is least?)
- Haven't tested hobbies yet, how do you get HOBCHK to be nonempty? (or should we get rid of hobbies completely?)

https://user-images.githubusercontent.com/32944104/110054783-95bbe580-7d10-11eb-8cf4-ae23124d29d6.mov

